### PR TITLE
update awslogs to apilogs

### DIFF
--- a/apilogs/_version.py
+++ b/apilogs/_version.py
@@ -1,3 +1,3 @@
 from pkg_resources import get_distribution
 
-__version__ = get_distribution("awslogs").version
+__version__ = get_distribution("apilogs").version


### PR DESCRIPTION
Using awslogs in the `_version.py` file causes the following error.
```$ apilogs --help   
Traceback (most recent call last):
  File "/usr/bin/apilogs", line 9, in <module>
    load_entry_point('apilogs==1.1', 'console_scripts', 'apilogs')()
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 542, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 2569, in load_entry_point
    return ep.load()
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib64/python2.7/site-packages/apilogs/__init__.py", line 1, in <module>
    from ._version import __version__  # noqa
  File "/usr/lib64/python2.7/site-packages/apilogs/_version.py", line 3, in <module>
    __version__ = get_distribution("awslogs").version
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 535, in get_distribution
    dist = get_provider(dist)
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 415, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 943, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 829, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'awslogs' distribution was not found and is required by the application```