### PR TITLE
Fix syntax errors on 3.x if exception are caught

### DIFF
--- a/apilogs/bin.py
+++ b/apilogs/bin.py
@@ -208,14 +208,7 @@ def main(argv=None):
 
 
 def configure_logging(verbosity):
-    level = logging.getLevelName(
-        {
-            0: 'ERROR',
-            1: 'WARNING',
-            2: 'INFO',
-            3: 'DEBUG'
-        }.get(verbosity, 'CRITICAL')
-    )
+    level = {0: 'ERROR', 1: 'WARNING', 2: 'INFO', 3: 'DEBUG'}[verbosity]
     fmt = '%(asctime)s %(funcName)s:%(lineno)s %(levelname)s: %(message)s'
     logging.basicConfig(level=level, format=fmt)
 

--- a/apilogs/bin.py
+++ b/apilogs/bin.py
@@ -208,12 +208,12 @@ def main(argv=None):
 
 
 def configure_logging(verbosity):
-    max_verbosity = verbosity > 3
-    verbosity = 3 if max_verbosity else verbosity
+    is_max_verbosity = verbosity > 3
+    verbosity = 3 if is_max_verbosity else verbosity
     level = {0: 'ERROR', 1: 'WARNING', 2: 'INFO', 3: 'DEBUG'}[verbosity]
     fmt = '%(asctime)s %(name)s:%(lineno)s %(levelname)s: %(message)s'
     logging.basicConfig(level=level, format=fmt)
-    if not max_verbosity:
+    if not is_max_verbosity:
         external_loggers = ['botocore']
         for name in external_loggers:
             logger = logging.getLogger(name)

--- a/apilogs/bin.py
+++ b/apilogs/bin.py
@@ -14,9 +14,6 @@ from .core import AWSLogs
 from ._version import __version__
 
 def main(argv=None):
-    fmt = '%(asctime)s %(funcName)s:%(lineno)s %(levelname)s: %(message)s'
-    logging.basicConfig(level=logging.DEBUG, format=fmt)
-
     if sys.version_info < (3, 0):
         sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
 
@@ -25,6 +22,8 @@ def main(argv=None):
     parser = argparse.ArgumentParser(usage=("%(prog)s [ get | groups | streams ]"))
     parser.add_argument("--version", action="version",
                         version="%(prog)s " + __version__)
+    parser.add_argument("-v", action="count", default=0,
+                        help="increase verbosity")
 
     def add_common_arguments(parser):
         parser.add_argument("--aws-access-key-id",
@@ -147,6 +146,8 @@ def main(argv=None):
     # Parse input
     options, args = parser.parse_known_args(argv)
 
+    configure_logging(options.v)
+
     if hasattr(options, 'api_id'):
         # build API Gateway log group name
         options.log_group_name = "API-Gateway-Execution-Logs_" + options.api_id + "/" + options.stage
@@ -204,6 +205,20 @@ def main(argv=None):
         return 1
 
     return 0
+
+
+def configure_logging(verbosity):
+    level = logging.getLevelName(
+        {
+            0: 'ERROR',
+            1: 'WARNING',
+            2: 'INFO',
+            3: 'DEBUG'
+        }.get(verbosity, 'CRITICAL')
+    )
+    fmt = '%(asctime)s %(funcName)s:%(lineno)s %(levelname)s: %(message)s'
+    logging.basicConfig(level=level, format=fmt)
+
 
 if __name__ == '__main__':
     main()

--- a/apilogs/bin.py
+++ b/apilogs/bin.py
@@ -23,7 +23,7 @@ def main(argv=None):
     parser.add_argument("--version", action="version",
                         version="%(prog)s " + __version__)
     parser.add_argument("-v", action="count", default=0,
-                        help="increase verbosity (-vvv for maximum verbosity)")
+                        help="increase verbosity (-vvvv for maximum)")
 
     def add_common_arguments(parser):
         parser.add_argument("--aws-access-key-id",
@@ -208,10 +208,16 @@ def main(argv=None):
 
 
 def configure_logging(verbosity):
+    max_verbosity = verbosity > 3
+    verbosity = 3 if max_verbosity else verbosity
     level = {0: 'ERROR', 1: 'WARNING', 2: 'INFO', 3: 'DEBUG'}[verbosity]
-    fmt = '%(asctime)s %(funcName)s:%(lineno)s %(levelname)s: %(message)s'
+    fmt = '%(asctime)s %(name)s:%(lineno)s %(levelname)s: %(message)s'
     logging.basicConfig(level=level, format=fmt)
-
+    if not max_verbosity:
+        external_loggers = ['botocore']
+        for name in external_loggers:
+            logger = logging.getLogger(name)
+            logger.setLevel(logging.ERROR)
 
 if __name__ == '__main__':
     main()

--- a/apilogs/bin.py
+++ b/apilogs/bin.py
@@ -23,7 +23,7 @@ def main(argv=None):
     parser.add_argument("--version", action="version",
                         version="%(prog)s " + __version__)
     parser.add_argument("-v", action="count", default=0,
-                        help="increase verbosity")
+                        help="increase verbosity (-vvv for maximum verbosity)")
 
     def add_common_arguments(parser):
         parser.add_argument("--aws-access-key-id",

--- a/apilogs/bin.py
+++ b/apilogs/bin.py
@@ -5,6 +5,7 @@ import codecs
 import argparse
 
 import boto3
+import logging
 from botocore.client import ClientError
 from termcolor import colored
 
@@ -13,6 +14,8 @@ from .core import AWSLogs
 from ._version import __version__
 
 def main(argv=None):
+    fmt = '%(asctime)s %(funcName)s:%(lineno)s %(levelname)s: %(message)s'
+    logging.basicConfig(level=logging.DEBUG, format=fmt)
 
     if sys.version_info < (3, 0):
         sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from setuptools import setup, find_packages
 install_requires = [
     'boto3>=1.2.1',
     'termcolor>=1.1.0',
-    'python-dateutil>=2.4.0'
+    'python-dateutil>=2.4.0',
+    'awslogs',
 ]
 
 # as of Python >= 2.7 argparse module is maintained within Python.


### PR DESCRIPTION
Some leftovers from pure 2.x time I guess.
Added logging instead of using print and made it configurable. Default is 'ERROR'.

also: I need awslogs installed to make it work, so it should be a requirement.