### PR TITLE
Fix #7 with no early return

### DIFF
--- a/apilogs/core.py
+++ b/apilogs/core.py
@@ -170,7 +170,7 @@ class AWSLogs(object):
                     log.warning("Error fetching logs for Lambda function {0}"
                                 " with group {1}. This function may need to be"
                                 " invoked.".format(fxn, lambda_group, e))
-                return allevents
+            return allevents
 
         ## todo: remove shared kwargs
         def list_apigateway_logs(allevents, kwargs):


### PR DESCRIPTION
Fix issue #7 

Identation level of allevents causes and early return from
the function list iterator. Move it out so that we iterate
through the whole list

Note: there's 1 failing test... but it was failing before these changes too. I have the logs from the test run if needed.